### PR TITLE
Fix for Mesh Provisioning and Proxy UUIDs

### DIFF
--- a/v1/characteristic_uuids.json
+++ b/v1/characteristic_uuids.json
@@ -342,9 +342,9 @@
     { "name": "micro:bit Temperature", "identifier": "org.microbit.characteristic.temperature", "uuid": "E95D9250-251D-470A-A062-FA1922DFA9A8" , "source": "microbit"},
     { "name": "micro:bit Temperature Period", "identifier": "org.microbit.characteristic.temperature_period", "uuid": "E95D1B25-251D-470A-A062-FA1922DFA9A8" , "source": "microbit"},
 
-    { "name": "Mesh Provisioning Data In", "identifier": "com.nordicsemi.service.mesh.provisioning.data_in", "uuid": "2ADB" , "source": "nordic"},
-    { "name": "Mesh Provisioning Data Out", "identifier": "com.nordicsemi.service.mesh.provisioning.data_out", "uuid": "2ADC" , "source": "nordic"},
+    { "name": "Mesh Provisioning Data In", "identifier": "org.bluetooth.characteristic.mesh_provisioning_data_in", "uuid": "2ADB" , "source": "gss"},
+    { "name": "Mesh Provisioning Data Out", "identifier": "org.bluetooth.characteristic.mesh_provisioning_data_out", "uuid": "2ADC" , "source": "gss"},
 
-    { "name": "Mesh Proxy Data In", "identifier": "com.nordicsemi.service.mesh.proxy.data_in", "uuid": "2ADD" , "source": "nordic"},
-    { "name": "Mesh Proxy Data Out", "identifier": "com.nordicsemi.service.mesh.proxy.data_out", "uuid": "2ADE" , "source": "nordic"}
+    { "name": "Mesh Proxy Data In", "identifier": "org.bluetooth.characteristic.mesh_proxy_data_in", "uuid": "2ADD" , "source": "gss"},
+    { "name": "Mesh Proxy Data Out", "identifier": "org.bluetooth.characteristic.mesh_proxy_data_out", "uuid": "2ADE" , "source": "gss"}
 ]

--- a/v1/service_uuids.json
+++ b/v1/service_uuids.json
@@ -68,11 +68,5 @@
 
     { "name": "Legacy DFU Service", "identifier": "com.nordicsemi.service.dfu.legacy", "uuid": "00001530-1212-EFDE-1523-785FEABCD123" , "source": "nordic"},
     { "name": "Secure DFU Service", "identifier": "com.nordicsemi.service.dfu.secure", "uuid": "FE59" , "source": "nordic"},
-    { "name": "Buttonless Experimental DFU Service", "identifier": "com.nordicsemi.service.dfu.buttonless_experimental", "uuid": "8E400001-F315-4F60-9FB8-838830DAEA50" , "source": "nordic"},
-
-    { "name": "Mesh Provisioning Data In", "identifier": "com.nordicsemi.service.mesh.provisioning.data_in", "uuid": "2ADB" , "source": "nordic"},
-    { "name": "Mesh Provisioning Data Out", "identifier": "com.nordicsemi.service.mesh.provisioning.data_out", "uuid": "2ADC" , "source": "nordic"},
-
-    { "name": "Mesh Proxy Data In", "identifier": "com.nordicsemi.service.mesh.proxy.data_in", "uuid": "2ADD" , "source": "nordic"},
-    { "name": "Mesh Proxy Data Out", "identifier": "com.nordicsemi.service.mesh.proxy.data_out", "uuid": "2ADE" , "source": "nordic"}
+    { "name": "Buttonless Experimental DFU Service", "identifier": "com.nordicsemi.service.dfu.buttonless_experimental", "uuid": "8E400001-F315-4F60-9FB8-838830DAEA50" , "source": "nordic"}
 ]


### PR DESCRIPTION
These UUIDs are available here https://www.bluetooth.com/xml-viewer/?src=https://www.bluetooth.com/wp-content/uploads/Sitecore-Media-Library/Gatt/Xml/Services/org.bluetooth.service.mesh_proxy.xml
And here https://www.bluetooth.com/xml-viewer/?src=https://www.bluetooth.com/wp-content/uploads/Sitecore-Media-Library/Gatt/Xml/Services/org.bluetooth.service.mesh_provisioning.xml