### PR TITLE
Add LEGO services and characteristics

### DIFF
--- a/v1/characteristic_uuids.json
+++ b/v1/characteristic_uuids.json
@@ -347,5 +347,8 @@
     { "name": "Mesh Provisioning Data Out", "identifier": "org.bluetooth.characteristic.mesh_provisioning_data_out", "uuid": "2ADC" , "source": "gss"},
 
     { "name": "Mesh Proxy Data In", "identifier": "org.bluetooth.characteristic.mesh_proxy_data_in", "uuid": "2ADD" , "source": "gss"},
-    { "name": "Mesh Proxy Data Out", "identifier": "org.bluetooth.characteristic.mesh_proxy_data_out", "uuid": "2ADE" , "source": "gss"}
+    { "name": "Mesh Proxy Data Out", "identifier": "org.bluetooth.characteristic.mesh_proxy_data_out", "uuid": "2ADE" , "source": "gss"},
+
+    { "name": "LEGO® Wireless Protocol v3 Hub Characteristic", "identifier": "com.lego.characteristic.lwp3.hub", "uuid": "00001624-1212-EFDE-1623-785FEABCD123", "source": "lego"},
+    { "name": "LEGO® Wireless Protocol v3 Bootloader Characteristic", "identifier": "com.lego.characteristic.lwp3.bootloader", "uuid": "00001626-1212-EFDE-1623-785FEABCD123", "source": "lego"}
 ]

--- a/v1/service_uuids.json
+++ b/v1/service_uuids.json
@@ -73,5 +73,8 @@
 
     { "name": "Exposure Notification Service", "identifier": "com.apple.service.contacttracing", "uuid": "FD6F" , "source": "apple"},
 
-    { "name": "SMP Service", "identifier": "io.runtime.mcumgr.ble.smp", "uuid": "8D53DC1D-1DB7-4CD3-868B-8A527460AA84" , "source": "apache"}
+    { "name": "SMP Service", "identifier": "io.runtime.mcumgr.ble.smp", "uuid": "8D53DC1D-1DB7-4CD3-868B-8A527460AA84" , "source": "apache"},
+
+    { "name": "LEGO® Wireless Protocol v3 Hub Service", "identifier": "com.lego.service.lwp3.hub", "uuid": "00001623-1212-EFDE-1623-785FEABCD123", "source": "lego"},
+    { "name": "LEGO® Wireless Protocol v3 Bootloader Service", "identifier": "com.lego.service.lwp3.bootloader", "uuid": "00001625-1212-EFDE-1623-785FEABCD123", "source": "lego"}
 ]


### PR DESCRIPTION
This adds LEGO-defined service and characteristic UUIDs for the [LEGO Wireless Protocol v3][1].

[1]: https://lego.github.io/lego-ble-wireless-protocol-docs/