### PR TITLE
Add TI OAD Profile

### DIFF
--- a/v1/characteristic_uuids.json
+++ b/v1/characteristic_uuids.json
@@ -392,5 +392,9 @@
     { "name": "Adafruit Proximity", "identifier": "com.adafruit.characteristic.proximity", "uuid": "ADAF0E01-C332-42A8-93BD-25E905756CB8", "source": "adafruit"},
 
     { "name": "Adafruit Version", "identifier": "com.adafruit.characteristic.file_transfer_version", "uuid": "ADAF0100-4669-6C65-5472-616E73666572", "source": "adafruit"},
-    { "name": "Adafruit Raw TX/RX", "identifier": "com.adafruit.characteristic.file_transfer_raw", "uuid": "ADAF0200-4669-6C65-5472-616E73666572", "source": "adafruit"}
+    { "name": "Adafruit Raw TX/RX", "identifier": "com.adafruit.characteristic.file_transfer_raw", "uuid": "ADAF0200-4669-6C65-5472-616E73666572", "source": "adafruit"},
+
+    { "name": "Texas Instruments Image Identify", "identifier": "com.ti.characteristic.image_identity", "uuid": "F000FFC1-0451-4000-B000-000000000000", "source": "ti"},
+    { "name": "Texas Instruments Image Block", "identifier": "com.ti.characteristic.image_block", "uuid": "F000FFC2-0451-4000-B000-000000000000", "source": "ti"},
+    { "name": "Texas Instruments OAD Control", "identifier": "com.ti.characteristic.oad_control", "uuid": "F000FFC5-0451-4000-B000-000000000000", "source": "ti"}
 ]

--- a/v1/service_uuids.json
+++ b/v1/service_uuids.json
@@ -92,5 +92,7 @@
     { "name": "Adafruit Sound Service", "identifier": "com.adafruit.service.sound", "uuid": "ADAF0B00-C332-42A8-93BD-25E905756CB8", "source": "adafruit"},
     { "name": "Adafruit Tone Service", "identifier": "com.adafruit.service.tone", "uuid": "ADAF0C00-C332-42A8-93BD-25E905756CB8", "source": "adafruit"},
     { "name": "Adafruit Quaternion Service", "identifier": "com.adafruit.service.quaternion", "uuid": "ADAF0D00-C332-42A8-93BD-25E905756CB8", "source": "adafruit"},
-    { "name": "Adafruit Proximity Service", "identifier": "com.adafruit.service.proximity", "uuid": "ADAF0E00-C332-42A8-93BD-25E905756CB8", "source": "adafruit"}
+    { "name": "Adafruit Proximity Service", "identifier": "com.adafruit.service.proximity", "uuid": "ADAF0E00-C332-42A8-93BD-25E905756CB8", "source": "adafruit"},
+
+    { "name": "Texas Instruments Over-the-Air Download (OAD) Service", "identifier": "com.ti.service.oad", "uuid": "F000FFC0-0451-4000-B000-000000000000", "source": "ti"}
 ]


### PR DESCRIPTION
This adds the Texas Instruments Over-the-Air Download (OAD) service and associated characteristics. This is used in a number of products based on TI chips.

Source: http://software-dl.ti.com/lprf/simplelink_cc26x2_latest/docs/ble5stack/ble_user_guide/html/ble-stack-oad/oad-profile.html