### PR TITLE
Fix for broken GitHub Actions

### DIFF
--- a/.github/workflows/verify_json.yml
+++ b/.github/workflows/verify_json.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:

--- a/.github/workflows/verify_no_duplicates.yml
+++ b/.github/workflows/verify_no_duplicates.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   build:
 
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-latest
 
     strategy:
       matrix:


### PR DESCRIPTION
I think we were using an Unsupported version of Ubuntu, as described here https://github.com/actions/virtual-environments
Reference: https://github.community/t/hosted-runners-not-picking-up-jobs/191663/14