### PR TITLE
Added Phillips Hue Light Services and Characteristics where Available

### DIFF
--- a/v1/characteristic_uuids.json
+++ b/v1/characteristic_uuids.json
@@ -244,6 +244,10 @@
 
     { "name": "SMP Characteristic", "identifier": "io.runtime.mcumgr.ble.smp", "uuid": "DA2E7828-FBCE-4E01-AE9E-261174997C48" , "source": "apache"},
 
+    { "name": "Phillips Hue Light On/Off Toggle", "identifier": "com.phillips-hue.characteristic.toggle", "uuid": "932C32BD-0002-47A2-835A-A8D455B859DD" , "source": "phillips-hue"},
+    { "name": "Phillips Hue Light Brightness Level", "identifier": "com.phillips-hue.characteristic.brightness", "uuid": "932C32BD-0003-47A2-835A-A8D455B859DD" , "source": "phillips-hue"},
+    { "name": "Phillips Hue Light Color", "identifier": "com.phillips-hue.characteristic.color", "uuid": "932C32BD-0005-47A2-835A-A8D455B859DD" , "source": "phillips-hue"},
+
     { "name": "Thingy Device Name", "identifier": "com.nordicsemi.characteristic.thingy.device_name", "uuid": "EF680101-9B35-4933-9B10-52FFA9740042" , "source": "nordic"},
     { "name": "Thingy Advertising Parameters", "identifier": "com.nordicsemi.characteristic.thingy.advertising_param", "uuid": "EF680102-9B35-4933-9B10-52FFA9740042" , "source": "nordic"},
     { "name": "Thingy Connection Parameters", "identifier": "com.nordicsemi.characteristic.thingy.connection_param", "uuid": "EF680104-9B35-4933-9B10-52FFA9740042" , "source": "nordic"},

--- a/v1/service_uuids.json
+++ b/v1/service_uuids.json
@@ -40,6 +40,12 @@
     { "name": "User Data", "identifier": "org.bluetooth.service.user_data" , "uuid": "181C" , "source": "gss"},
     { "name": "Weight Scale", "identifier": "org.bluetooth.service.weight_scale", "uuid": "181D" , "source": "gss"},
 
+    { "name": "Signify Netherlands B.V. (formerly Phillips Lighting) Service", "identifier": "com.phillips-hue.service.signify_netherlands", "uuid": "FE0F" , "source": "phillips-hue"},
+
+    { "name": "Phillips Hue Light Control Service", "identifier": "com.phillips-hue.service.light_control", "uuid": "932C32BD-0000-47A2-835A-A8D455B859DD" , "source": "phillips-hue"},
+    { "name": "Phillips Hue Light Information Service", "identifier": "com.phillips-hue.service.light_information", "uuid": "0000180A-0000-1000-8000-00805F9B34FB" , "source": "phillips-hue"},
+    { "name": "Phillips Hue Light Update Service", "identifier": "com.phillips-hue.service.light_update", "uuid": "B8843ADD-0000-4AA1-8794-C3F462030BDA" , "source": "phillips-hue"},
+
     { "name": "Apple Notification Center Service", "identifier": "com.apple.service.notification_center", "uuid": "7905F431-B5CE-4E99-A40F-4B1E122D00D0" , "source": "apple"},
     { "name": "Apple Media Service", "identifier": "com.apple.service.media", "uuid": "89D3502B-0F36-433A-8EF4-C502AD55F8DC" , "source": "apple"},
 


### PR DESCRIPTION
There's no Official Documentation from Phillips, so we've reverse-engineered what was possible to add some light (please forgive me) into its UUID Numbers. We would like to do a lot better, but at the moment this is the best we can do. We will keep updating these as we gather more information.
Reference: https://www.reddit.com/r/Hue/comments/eq0y3y/philips_hue_bluetooth_developer_documentation/