### PR TITLE
Fix Philips Hue services and characteristics

### DIFF
--- a/v1/characteristic_uuids.json
+++ b/v1/characteristic_uuids.json
@@ -444,9 +444,9 @@
 
     { "name": "SMP Characteristic", "identifier": "io.runtime.mcumgr.ble.smp", "uuid": "DA2E7828-FBCE-4E01-AE9E-261174997C48" , "source": "apache"},
 
-    { "name": "Phillips Hue Light On/Off Toggle", "identifier": "com.phillips-hue.characteristic.toggle", "uuid": "932C32BD-0002-47A2-835A-A8D455B859DD" , "source": "phillips-hue"},
-    { "name": "Phillips Hue Light Brightness Level", "identifier": "com.phillips-hue.characteristic.brightness", "uuid": "932C32BD-0003-47A2-835A-A8D455B859DD" , "source": "phillips-hue"},
-    { "name": "Phillips Hue Light Color", "identifier": "com.phillips-hue.characteristic.color", "uuid": "932C32BD-0005-47A2-835A-A8D455B859DD" , "source": "phillips-hue"},
+    { "name": "Philips Hue Light On/Off Toggle", "identifier": "com.philips-hue.characteristic.toggle", "uuid": "932C32BD-0002-47A2-835A-A8D455B859DD" , "source": "philips-hue"},
+    { "name": "Philips Hue Light Brightness Level", "identifier": "com.philips-hue.characteristic.brightness", "uuid": "932C32BD-0003-47A2-835A-A8D455B859DD" , "source": "philips-hue"},
+    { "name": "Philips Hue Light Color", "identifier": "com.philips-hue.characteristic.color", "uuid": "932C32BD-0005-47A2-835A-A8D455B859DD" , "source": "philips-hue"},
 
     { "name": "Thingy Device Name", "identifier": "com.nordicsemi.characteristic.thingy.device_name", "uuid": "EF680101-9B35-4933-9B10-52FFA9740042" , "source": "nordic"},
     { "name": "Thingy Advertising Parameters", "identifier": "com.nordicsemi.characteristic.thingy.advertising_param", "uuid": "EF680102-9B35-4933-9B10-52FFA9740042" , "source": "nordic"},

--- a/v1/service_uuids.json
+++ b/v1/service_uuids.json
@@ -62,11 +62,10 @@
     { "name": "Hearing Access", "identifier": "org.bluetooth.service.hearing_access", "uuid": "1854", "source": "gss" },
     { "name": "TMAS", "identifier": "org.bluetooth.service.tmas", "uuid": "1855", "source": "gss" },
 
-    { "name": "Signify Netherlands B.V. (formerly Phillips Lighting) Service", "identifier": "com.phillips-hue.service.signify_netherlands", "uuid": "FE0F" , "source": "phillips-hue"},
+    { "name": "Signify Netherlands B.V. (formerly Philips Lighting) Service", "identifier": "com.philips-hue.service.signify_netherlands", "uuid": "FE0F" , "source": "philips-hue"},
 
-    { "name": "Phillips Hue Light Control Service", "identifier": "com.phillips-hue.service.light_control", "uuid": "932C32BD-0000-47A2-835A-A8D455B859DD" , "source": "phillips-hue"},
-    { "name": "Phillips Hue Light Information Service", "identifier": "com.phillips-hue.service.light_information", "uuid": "0000180A-0000-1000-8000-00805F9B34FB" , "source": "phillips-hue"},
-    { "name": "Phillips Hue Light Update Service", "identifier": "com.phillips-hue.service.light_update", "uuid": "B8843ADD-0000-4AA1-8794-C3F462030BDA" , "source": "phillips-hue"},
+    { "name": "Philips Hue Light Control Service", "identifier": "com.philips-hue.service.light_control", "uuid": "932C32BD-0000-47A2-835A-A8D455B859DD" , "source": "philips-hue"},
+    { "name": "Philips Hue Light Update Service", "identifier": "com.philips-hue.service.light_update", "uuid": "B8843ADD-0000-4AA1-8794-C3F462030BDA" , "source": "philips-hue"},
 
     { "name": "Apple Notification Center Service", "identifier": "com.apple.service.notification_center", "uuid": "7905F431-B5CE-4E99-A40F-4B1E122D00D0" , "source": "apple"},
     { "name": "Apple Media Service", "identifier": "com.apple.service.media", "uuid": "89D3502B-0F36-433A-8EF4-C502AD55F8DC" , "source": "apple"},


### PR DESCRIPTION
- The company is called Philips, not Phillips.
- The Phillips Hue Light Information Service with UUID 0000180A-0000-1000-8000-00805F9B34FB doesn't exist. It's just the Device Information service with 16-bit UUID 180A.